### PR TITLE
Fix broken link to manual installation in package manager docs

### DIFF
--- a/src/administration-guide/installation/package-manager.md
+++ b/src/administration-guide/installation/package-manager.md
@@ -9,7 +9,7 @@
   Ansible and Git should be installed on your system.
 </div>
 
-Look into the [manual installation](./installation_manually.md) on how to set-up your Python/Ansible/Systemd environment!
+Look into the [manual installation](./../installation_manually.md) on how to set-up your Python/Ansible/Systemd environment!
 
 Download package file from [Releases page](https://github.com/semaphoreui/semaphore/releases).
 


### PR DESCRIPTION
Hey,

i just installed Semaphore via the package manager and noticed this broken link. Thank you for all the work you did already for Semaphore. It will make my life easier managing a lot of ansible managed servers :) 