### PR TITLE
Authelia: Add a claims policy for Semaphore

### DIFF
--- a/src/administration-guide/openid/authelia.md
+++ b/src/administration-guide/openid/authelia.md
@@ -9,9 +9,20 @@ Authelia `config.yaml`:
 ```yaml
 identity_providers:
   oidc:
+    claims_policies:
+      semaphore_claims_policy:
+        id_token:
+          - groups
+          - email
+          - email_verified
+          - alt_emails
+          - preferred_username
+          - name
+  clients:
     - client_id: semaphore
       client_name: Semaphore
       client_secret: 'your_secret'
+      claims_policy: semaphore_claims_policy
       public: false
       authorization_policy: two_factor
       redirect_uris:

--- a/src/administration-guide/openid/authelia.md
+++ b/src/administration-guide/openid/authelia.md
@@ -18,20 +18,20 @@ identity_providers:
           - alt_emails
           - preferred_username
           - name
-  clients:
-    - client_id: semaphore
-      client_name: Semaphore
-      client_secret: 'your_secret'
-      claims_policy: semaphore_claims_policy
-      public: false
-      authorization_policy: two_factor
-      redirect_uris:
-        - https://your-semaphore-domain.com/api/auth/oidc/authelia/redirect
-      scopes:
-        - openid
-        - profile
-        - email
-      userinfo_signed_response_alg: none
+    clients:
+      - client_id: semaphore
+        client_name: Semaphore
+        client_secret: 'your_secret'
+        claims_policy: semaphore_claims_policy
+        public: false
+        authorization_policy: two_factor
+        redirect_uris:
+          - https://your-semaphore-domain.com/api/auth/oidc/authelia/redirect
+        scopes:
+          - openid
+          - profile
+          - email
+        userinfo_signed_response_alg: none
 ```
 
 Semaphore `config.json`:


### PR DESCRIPTION
The claims policy is required since a change in authelia. More details on the change here:

https://www.authelia.com/integration/openid-connect/openid-connect-1.0-claims/#restore-functionality-prior-to-claims-parameter