### PR TITLE
docs(ansible): document template working directory

### DIFF
--- a/docs/user-guide/apps/ansible.md
+++ b/docs/user-guide/apps/ansible.md
@@ -13,6 +13,7 @@ The template allows you to specify the following parameters:
 
 * Repository
 * Path to playbook file
+* Working directory (optional)
 * Inventory
 * Variable Groups
 * Vaults
@@ -20,6 +21,22 @@ The template allows you to specify the following parameters:
 * Environment variables
 
 ![](/assets/ansible_2.png)
+
+## Working directory
+
+Use **Working directory** to run Ansible commands from a subdirectory of the template repository. Enter a path relative to the repository root. For example, if `ansible.cfg` is stored in `<repository>/automation`, enter `automation`. Absolute paths and paths outside the repository are rejected. If omitted, Semaphore uses the repository root.
+
+The working directory affects Ansible behavior that depends on the process's current directory. Ansible's [configuration file search order][ansible-config-search] includes `ansible.cfg` in the current directory. The working directory also affects resolution of relative paths in extra CLI arguments; examples include [`--extra-vars @vars.yml`][ansible-extra-vars-file] and [`--private-key key.pem`][ansible-private-key]. Playbook and file-inventory paths remain relative to their repository roots.
+
+Changing the working directory does not by itself add that directory's `roles/` or `collections/` subdirectory to Ansible's search paths. [Playbook-relative role discovery][ansible-role-search] and [collections adjacent to a playbook][ansible-playbook-collections] remain based on the playbook location. The working directory can still affect their discovery indirectly when the selected `ansible.cfg` configures `roles_path` or `collections_path`.
+
+[ansible-config-search]: https://docs.ansible.com/ansible/latest/reference_appendices/config.html#the-configuration-file
+[ansible-extra-vars-file]: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#vars-from-a-json-or-yaml-file
+[ansible-private-key]: https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html#cmdoption-ansible-playbook-private-key
+[ansible-role-search]: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#storing-and-finding-roles
+[ansible-playbook-collections]: https://docs.ansible.com/ansible/latest/collections_guide/collections_installing.html#installing-collections-adjacent-to-playbooks
+
+## Template types
 
 An ansible-playbook template can be one of the following types:
 
@@ -47,6 +64,8 @@ This type of template should be used to deploy artifacts to the destination serv
 
 
 This allows you to deploy a specific version of the artifact to the servers.
+
+## Template options
 
 ### Schedule
 

--- a/docs/user-guide/task-templates/prompts.md
+++ b/docs/user-guide/task-templates/prompts.md
@@ -164,14 +164,14 @@ Terraform prompts are available in the template settings:
 
 The task form displays these options when running Terraform tasks.
 
-## Shell, Bash, PowerShell, and Python Prompts
+## Bash, PowerShell, and Python Prompts
 
-For script-based templates (Shell, Bash, PowerShell, Python), prompts are minimal as most customization is handled through [Survey Variables](/survey-vars).
+For Bash, PowerShell, and Python templates, prompts are minimal as most customization is handled through [Survey Variables](/survey-vars).
 
-Available options typically include:
-- Script path or command selection
-- Execution environment settings
-- Working directory
+Available prompts are:
+
+- CLI args
+- Branch
 
 These template types benefit more from custom Survey Variables for passing parameters to scripts.
 


### PR DESCRIPTION
   ## Summary

   - document the optional repository-relative working directory for Ansible templates
   - explain how it affects `ansible.cfg` discovery and relative CLI file arguments
   - clarify that playbook and file-inventory paths remain repository-rooted
   - document how role and collection discovery relates to the playbook and selected `ansible.cfg`
   - link to the relevant official Ansible documentation
   - correct the documented prompts for Bash, PowerShell, and Python templates to list only CLI args and Branch

   This is companion documentation for SEM-210.
