### PR TITLE
docs: add workflows guide and document recent runner/ansible features

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Semaphore is written in **Go** (lightweight, fast) and runs on **Windows**, **ma
 
 - **I’m using Semaphore day-to-day (teams/users)**
   - Organize work: [Projects](/user-guide/projects) and [Teams](/user-guide/team)
-  - Run automation: [Tasks](/user-guide/tasks) and [Schedules](/user-guide/schedules)
+  - Run automation: [Tasks](/user-guide/tasks), [Workflows](/user-guide/workflows) (Pro), and [Schedules](/user-guide/schedules)
   - Connect your code: [Repositories](/user-guide/repositories)
   - Targets and variables: [Inventory](/user-guide/inventory) and [Variable Groups](/user-guide/environment)
   - Credentials: [Key Store](/user-guide/key-store)
@@ -60,6 +60,7 @@ If you’re new, these terms show up everywhere in the UI:
 - **Variable Group (Environment)**: reusable variables and configuration per project — [Variable Groups](/user-guide/environment)
 - **Key Store**: encrypted credentials (SSH keys, tokens, passwords) — [Key Store](/user-guide/key-store)
 - **Task / Task template**: the definition and the run of automation — [Tasks](/user-guide/tasks)
+- **Workflow**: a directed graph of task templates with branching, approvals, and delays (Pro) — [Workflows](/user-guide/workflows)
 - **Runner**: where tasks execute (local or remote) — [Runners](/admin-guide/runners)
 
 ## Common workflows

--- a/docs/admin-guide/cli/runners.md
+++ b/docs/admin-guide/cli/runners.md
@@ -49,6 +49,21 @@ nohup ./semaphore runner start --config /path/to/config.runner.json &
 You can edit the generated configuration file by hand afterward instead of
 re-running setup.
 
+### Runner configuration options
+
+Common fields in the `runner` block of the configuration file:
+
+| Field | Env variable | Description |
+|-------|--------------|-------------|
+| `token` / `token_file` | `SEMAPHORE_RUNNER_TOKEN` / `SEMAPHORE_RUNNER_TOKEN_FILE` | Runner authentication token (issued at registration). |
+| `check_interval_seconds` | `SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS` | Poll interval in seconds. Default: 1. |
+| `max_parallel_tasks` | `SEMAPHORE_RUNNER_MAX_PARALLEL_TASKS` | Maximum concurrent tasks. Default: 9999. |
+| `tags` | `SEMAPHORE_RUNNER_TAGS` | JSON array of tags for project runner routing. |
+| `one_off` | `SEMAPHORE_RUNNER_ONE_OFF` | Exit after processing one job. |
+
+See [Runners](/admin-guide/runners) for setup details and
+[Configuration](/admin-guide/configuration) for the full option list.
+
 ## Registering a runner (`runner register`)
 
 Registers the runner on the server and stores the issued runner token in the

--- a/docs/admin-guide/configuration.md
+++ b/docs/admin-guide/configuration.md
@@ -55,6 +55,7 @@ Full list of available configuration options:
 | <br />`runner.name` <hr /> `SEMAPHORE_RUNNER_NAME` <br /><br /> | Runner name. |
 | <br />`runner.tags` <hr /> `SEMAPHORE_RUNNER_TAGS` <br /><br /> | JSON array of runner tags. |
 | <br />`runner.max_parallel_tasks` <hr /> `SEMAPHORE_RUNNER_MAX_PARALLEL_TASKS` <br /><br /> | Max number of parallel tasks for the runner. Default: 9999. |
+| <br />`runner.check_interval_seconds` <hr /> `SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS` <br /><br /> | How often the runner polls the server for new jobs and reports progress, in seconds. Default: 1. Higher values reduce request volume at the cost of slightly slower job pickup. |
 | <br />`runner.project_id` <hr /> `SEMAPHORE_RUNNER_PROJECT_ID` <br /><br /> | Restrict the runner to a single project. |
 | <br />`runner.connection.server_ca_cert_file` <hr /> `SEMAPHORE_RUNNER_SERVER_CA_CERT_FILE` <br /><br /> | PEM bundle used to verify the Semaphore server certificate, in addition to the system trust store. Set when the server uses a self-signed or internal-CA certificate. |
 | <br />`runner.connection.skip_tls_verify` <hr /> `SEMAPHORE_RUNNER_SKIP_TLS_VERIFY` <br /><br /> | Disable server certificate verification entirely. Insecure (vulnerable to MITM) — use only for testing. |

--- a/docs/admin-guide/runners.md
+++ b/docs/admin-guide/runners.md
@@ -87,12 +87,13 @@ As a result of running the `semaphore runner setup` command, a configuration fil
   "runner": {
     "token": "your runner's token",
     // or
-    "token_file": "path/to/the/file/where/runner/saves/token"
+    "token_file": "path/to/the/file/where/runner/saves/token",
 
-    // Here you can provide other runner-specific options, 
-    // which will be used for runner registration, for example: 
-    // max_parallel_tasks, webhook, one_off, etc.
-    // ...
+    // How often (in seconds) the runner polls the server for jobs and reports
+    // progress. Default: 1. Raise this when many runners share one server.
+    "check_interval_seconds": 1
+
+    // Other runner-specific options: max_parallel_tasks, webhook, one_off, etc.
   }
 }
 ```
@@ -110,6 +111,35 @@ semaphore runner start --config /path/to/your/config/file.json
 ```
 
 Your runner is ready to execute tasks.
+
+### Poll interval (`check_interval_seconds`)
+
+Each runner polls the Semaphore server on a fixed interval for new jobs and to
+report task progress. Configure it in the runner configuration file:
+
+```json
+{
+  "runner": {
+    "check_interval_seconds": 5
+  }
+}
+```
+
+Or with an environment variable:
+
+```bash
+SEMAPHORE_RUNNER_CHECK_INTERVAL_SECONDS=5
+```
+
+| Value | Effect |
+|-------|--------|
+| **1** (default) | Jobs are picked up within about one second; best for low-latency runs. |
+| **Higher** (e.g. 5–30) | Reduces HTTP traffic when you operate many runners against one server. Jobs may start slightly later. |
+
+The Runners page in the Semaphore UI exposes this under **Advanced options** when
+generating setup snippets (config file, Docker, and environment-variable examples).
+
+Invalid or zero values fall back to the default of 1 second.
 
 ### Runner tags (Pro)
 
@@ -131,9 +161,13 @@ semaphore runner unregister --config /path/to/your/config/file.json
 
 ## Security
 
-Data transfer security is ensured by using asymmetric encryption: the server encrypts data using a public key, the runner decrypts it using a private key.
-
-Public and private keys are generated automatically when the runner registers on the server.
+Runners authenticate to the server with an opaque bearer token
+(`X-Runner-Token`), issued at registration. Protect this token like any other
+credential — store it in a restricted configuration file or secret manager.
 
 :::warning
-  Use the HTTPS protocol for communication between the server and the runner, especially if they are not on the same private network.
+Use HTTPS for communication between the server and the runner, especially when
+they are not on the same private network. For self-signed or internal CA
+certificates, configure `runner.connection.server_ca_cert_file` on the runner.
+Do not use `runner.connection.skip_tls_verify` in production.
+:::

--- a/docs/user-guide/apps/ansible.md
+++ b/docs/user-guide/apps/ansible.md
@@ -70,6 +70,29 @@ Templates support Ansible CLI options:
 
 These can be set in the template and overridden when creating a task. Ensure corresponding prompts are enabled if you plan to pass these values via API.
 
+### Parallelism (`--forks` / `-f`)
+
+Control how many hosts Ansible connects to in parallel by passing `--forks` or
+`-f` in the template's **Extra CLI arguments**. Arguments must be valid JSON —
+use an array of separate tokens:
+
+```json
+["--forks", "10"]
+```
+
+Short form is also supported:
+
+```json
+["-f", "10"]
+```
+
+When **Allow override arguments in task** is enabled on the template, a task can
+supply its own forks value at run time. Ansible receives both the template and
+task arguments; the last `--forks` / `-f` on the command line wins.
+
+If arguments are not valid JSON, the task fails with a descriptive validation
+error before execution starts.
+
 ### Authentication
 
 Authentication for hosts in the playbook is done using the user references from the Key Store on the inventory. The user for SSH is determined by the optional user on the Key Store element.

--- a/docs/user-guide/workflows.md
+++ b/docs/user-guide/workflows.md
@@ -1,0 +1,130 @@
+# Workflows (Pro)
+
+Workflows let you chain multiple task templates into a directed graph (DAG) with
+branching, approvals, and timed pauses. A workflow run progresses automatically
+as each step finishes — you design the graph once in the visual editor, then
+launch runs from the Workflows page.
+
+:::info
+Workflows are a **Semaphore Pro** feature. The Workflows menu item appears only
+when your subscription includes them.
+:::
+
+## Overview
+
+A workflow consists of:
+
+- **Nodes** — steps in the graph (run a template, wait for approval, pause for a
+  delay, or annotate with a note).
+- **Edges** — connections between nodes, each labeled with a **condition** that
+  controls when the downstream node starts.
+
+When you start a workflow, Semaphore creates a **workflow run**. The server
+drives progression: as tasks complete, approvals are resolved, or delays expire,
+downstream nodes are launched according to the edge conditions.
+
+## Creating a workflow
+
+1. Open your project and go to **Workflows**.
+2. Click **New Workflow**.
+3. In the graphical editor:
+   - Drag nodes from the palette onto the canvas.
+   - Connect nodes by dragging from one node's output handle to another.
+   - Click a node or edge to edit its properties in the side panel.
+4. Set a **name** (and optionally a **start version** for run versioning).
+5. Fix any problems listed in the **Problems** panel, then click **Save**.
+
+The editor validates the graph before saving. A valid workflow must have at least
+one node, exactly one starting node (no incoming edges), no cycles, and complete
+configuration on every executable node.
+
+## Node kinds
+
+| Kind | Purpose |
+|------|---------|
+| **Task** | Runs a task template. You can override template parameters (inventory, environment, Ansible limit, extra CLI arguments) per node via **task params**. |
+| **Approval** | Pauses the run until a user with permission approves or rejects. Optionally set a timeout (seconds) and an approval message. |
+| **Delay** | Waits for a configured number of seconds before continuing to downstream nodes. Useful for cooling-off periods, maintenance windows, or spacing out dependent steps. |
+| **Note** | Free-form annotation on the canvas. Note nodes do not execute and are not connected by edges — they are for documentation only. |
+
+### Convergence
+
+Nodes with multiple incoming edges can require **all** upstream nodes to finish
+(default) or **any** one of them. Set **Convergence** in the node property panel.
+
+### Delay nodes
+
+A delay node pauses the workflow run for the configured duration (minimum 1
+second). While waiting:
+
+- The run stays in **running** status.
+- The run view shows a live countdown on the delay node.
+- Downstream nodes connected via edges are not started until the delay completes.
+
+If the workflow run is **stopped** while a delay is active, the delay is
+cancelled and the run ends in **stopped** status.
+
+### Approval nodes
+
+When the run reaches an approval node, status changes to **approval** until
+someone approves or rejects. Approve/Reject controls appear on the run view.
+Rejected approvals fail the run according to the connected edge conditions.
+
+## Edge conditions
+
+Each edge has a condition that determines when the downstream node becomes ready:
+
+| Condition | Downstream starts when the upstream node… |
+|-----------|-------------------------------------------|
+| **On success** | Finishes successfully (default). |
+| **On failure** | Finishes with an error. |
+| **Always** | Finishes in any terminal state (success or failure). |
+
+Use **On failure** branches for compensating actions or notifications. Use
+**Always** when the next step should run regardless of outcome.
+
+## Running and monitoring
+
+- **Run workflow** — starts a new run from the Workflows list.
+- **Run view** — full-screen graph with live status on each node (running,
+  success, failed, waiting for approval, delay countdown).
+- **Stop** — while a run is `running` or `approval`, users with
+  `run_project_tasks` can stop it. All active tasks are stopped, pending
+  approvals are rejected, and the run is marked **stopped**.
+
+Run statuses: `running`, `approval`, `success`, `failed`, `stopped`.
+
+## Run versioning
+
+Set **Start version** on the workflow (for example `1.0.0`) to enable version
+labels on each run. Semaphore increments the version on successive runs, similar
+to build templates.
+
+## Workflow artifacts (set_stats)
+
+When an Ansible task in a workflow uses `set_stats`, the variables are stored as
+**workflow artifacts** for that run. Downstream task nodes in the same run
+receive them as extra variables automatically.
+
+:::warning
+If steps in the workflow run on **remote runners**, workflow artifacts do not yet
+flow across remote-runner steps — they are only passed between tasks executed
+locally on the Semaphore server. Plan artifact hand-offs accordingly or keep
+artifact-producing and -consuming steps on the same execution path.
+:::
+
+## Permissions
+
+- Managing workflows (create, edit, delete) requires project resource management
+  permissions.
+- Running workflows requires `run_project_tasks`.
+- Resolving approvals requires appropriate project access (same users who can run
+  tasks in the project).
+
+## API
+
+Workflow templates and runs are available under
+`/api/project/{project_id}/workflows`. See the
+[API documentation](/admin-guide/api) for request and response schemas, including
+`delay` node fields (`delay_seconds`) and the stop endpoint
+(`POST …/runs/{run_id}/stop`).

--- a/docs/user-guide/workflows.md
+++ b/docs/user-guide/workflows.md
@@ -86,8 +86,8 @@ Use **On failure** branches for compensating actions or notifications. Use
 ## Running and monitoring
 
 - **Run workflow** — starts a new run from the Workflows list.
-- **Run view** — full-screen graph with live status on each node (running,
-  success, failed, waiting for approval, delay countdown).
+- **Run view** — full-screen graph with live status on each node (running, success,
+  failed, approval, delay countdown).
 - **Stop** — while a run is `running` or `approval`, users with
   `run_project_tasks` can stop it. All active tasks are stopped, pending
   approvals are rejected, and the run is marked **stopped**.

--- a/sidebars.js
+++ b/sidebars.js
@@ -181,6 +181,7 @@ const sidebars = {
           ],
         },
         'user-guide/tasks',
+        'user-guide/workflows',
         'user-guide/schedules',
         {
           type: 'category',


### PR DESCRIPTION
- New Pro workflows user guide covering delay nodes, approvals, and artifacts
- Document runner check_interval_seconds in admin guides
- Document Ansible --forks/-f in extra CLI arguments
- Fix outdated runner asymmetric-encryption security claim
