### PR TITLE
Clarify activity and task file logging

### DIFF
--- a/docs/admin-guide/logs.md
+++ b/docs/admin-guide/logs.md
@@ -24,11 +24,10 @@ This provides a live (streaming) view of the logs.
 
 ## Activity log {#activity-log}
 
-The Activity Log captures all user actions performed in Semaphore, including:
+The Activity Log captures user actions performed in Semaphore, including:
 
 - Adding or removing resources (e.g., Templates, Inventories, Repositories).
 - Adding or removing team members.
-- Starting or stopping tasks.
 
 ### Pro version 2.10 and later {#pro-version-210-and-later}
 
@@ -64,21 +63,21 @@ Or you can do this using following environment variables:
 
 ```bash
 export SEMAPHORE_EVENT_LOG_ENABLED=True
-export SEMAPHORE_EVENT_LOG_LOGGER={"filename": "./events.log"}
+export SEMAPHORE_EVENT_LOGGER={"filename": "./events.log"}
 
 export SEMAPHORE_TASK_LOG_ENABLED=True
-export SEMAPHORE_EVENT_LOG_LOGGER={"filename": "./tasks.log"}
+export SEMAPHORE_TASK_LOGGER={"filename": "./tasks.log"}
 ```
 
 #### Activity (events) logging options {#activity-events-logging-options}
 
-The Activity (events) logging options allow you to configure how Semaphore records user actions and system events to a file. These settings control the behavior of event logging, including whether it's enabled, the format of log entries, and specific logger configurations. When enabled, all user actions (like creating templates, managing teams, or running tasks) will be written to the specified log file according to these settings.
+The Activity (events) logging options allow you to configure how Semaphore records user actions and system events to a file. These settings control the behavior of event logging, including whether it's enabled, the format of log entries, and specific logger configurations. When enabled, user actions like creating templates or managing teams will be written to the specified log file according to these settings.
 
 | Parameter             | Environment Variables | Description           |
 | --------------------- | --------------------- | --------------------- |
 | `enabled`             | `SEMAPHORE_EVENT_LOG_ENABLED` | Enable event logging to file. |
-| `format`              | `SEMAPHORE_EVENT_LOG_FORMAT`  | Log record format. Can be `raw` or `json`. |
-| `logger`              | `SEMAPHORE_EVENT_LOG_LOGGER`  | [Logger options](#logger-options). |
+| `format`              | `SEMAPHORE_EVENT_LOG_FORMAT`  | Log record format. Leave empty for raw format, or set to `json`. |
+| `logger`              | `SEMAPHORE_EVENT_LOGGER`      | [Logger options](#logger-options). |
 
 #### Tasks logging options {#tasks-logging-options}
 
@@ -87,8 +86,8 @@ The Tasks logging options allow you to configure how Semaphore records task exec
 | Parameter             | Environment Variables | Description           |
 | --------------------- | --------------------- | --------------------- |
 | `enabled`             | `SEMAPHORE_TASK_LOG_ENABLED` | Enable task logging to file. |
-| `format`              | `SEMAPHORE_TASK_LOG_FORMAT`  | Log record format. Can be `raw` or `json`. |
-| `logger`              | `SEMAPHORE_TASK_LOG_LOGGER`  | [Logger options](#logger-options). |
+| `format`              | `SEMAPHORE_TASK_LOG_FORMAT`  | Log record format. Leave empty for raw format, or set to `json`. |
+| `logger`              | `SEMAPHORE_TASK_LOGGER`      | [Logger options](#logger-options). |
 | `result_logger`       | `SEMAPHORE_TASK_RESULT_LOGGER`  | Logger options. |
 
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/admin-guide/logs.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/admin-guide/logs.md
@@ -24,11 +24,10 @@ Dies liefert eine Live-Ansicht (Streaming) der Protokolle.
 
 ## Aktivitätsprotokoll {#activity-log}
 
-Das Aktivitätsprotokoll erfasst alle in Semaphore ausgeführten Benutzeraktionen, darunter:
+Das Aktivitätsprotokoll erfasst Benutzeraktionen in Semaphore, darunter:
 
 - Hinzufügen oder Entfernen von Ressourcen (z. B. Vorlagen, Inventories, Repositories).
 - Hinzufügen oder Entfernen von Teammitgliedern.
-- Starten oder Stoppen von Tasks.
 
 ### Pro-Version 2.10 und neuer {#pro-version-210-and-later}
 
@@ -64,21 +63,21 @@ Alternativ können Sie dies über die folgenden Umgebungsvariablen erreichen:
 
 ```bash
 export SEMAPHORE_EVENT_LOG_ENABLED=True
-export SEMAPHORE_EVENT_LOG_LOGGER={"filename": "./events.log"}
+export SEMAPHORE_EVENT_LOGGER={"filename": "./events.log"}
 
 export SEMAPHORE_TASK_LOG_ENABLED=True
-export SEMAPHORE_EVENT_LOG_LOGGER={"filename": "./tasks.log"}
+export SEMAPHORE_TASK_LOGGER={"filename": "./tasks.log"}
 ```
 
 #### Optionen für die Aktivitäts-(Ereignis-)Protokollierung {#activity-events-logging-options}
 
-Mit den Optionen für die Aktivitäts-(Ereignis-)Protokollierung legen Sie fest, wie Semaphore Benutzeraktionen und Systemereignisse in eine Datei schreibt. Diese Einstellungen steuern das Verhalten der Ereignisprotokollierung, einschließlich der Frage, ob sie aktiviert ist, des Formats der Protokolleinträge und der spezifischen Logger-Konfiguration. Wenn sie aktiviert ist, werden alle Benutzeraktionen (wie das Erstellen von Vorlagen, das Verwalten von Teams oder das Ausführen von Tasks) gemäß diesen Einstellungen in die angegebene Protokolldatei geschrieben.
+Mit den Optionen für die Aktivitäts-(Ereignis-)Protokollierung legen Sie fest, wie Semaphore Benutzeraktionen und Systemereignisse in eine Datei schreibt. Diese Einstellungen steuern das Verhalten der Ereignisprotokollierung, einschließlich der Frage, ob sie aktiviert ist, des Formats der Protokolleinträge und der spezifischen Logger-Konfiguration. Wenn sie aktiviert ist, werden Benutzeraktionen wie das Erstellen von Vorlagen oder das Verwalten von Teams gemäß diesen Einstellungen in die angegebene Protokolldatei geschrieben.
 
 | Parameter             | Umgebungsvariablen | Beschreibung          |
 | --------------------- | --------------------- | --------------------- |
 | `enabled`             | `SEMAPHORE_EVENT_LOG_ENABLED` | Aktiviert die Ereignisprotokollierung in eine Datei. |
-| `format`              | `SEMAPHORE_EVENT_LOG_FORMAT`  | Format der Protokolleinträge. Kann `raw` oder `json` sein. |
-| `logger`              | `SEMAPHORE_EVENT_LOG_LOGGER`  | [Logger-Optionen](#logger-options). |
+| `format`              | `SEMAPHORE_EVENT_LOG_FORMAT`  | Format der Protokolleinträge. Für das Raw-Format leer lassen oder `json` festlegen. |
+| `logger`              | `SEMAPHORE_EVENT_LOGGER`      | [Logger-Optionen](#logger-options). |
 
 #### Optionen für die Task-Protokollierung {#tasks-logging-options}
 
@@ -87,8 +86,8 @@ Mit den Optionen für die Task-Protokollierung legen Sie fest, wie Semaphore Det
 | Parameter             | Umgebungsvariablen | Beschreibung          |
 | --------------------- | --------------------- | --------------------- |
 | `enabled`             | `SEMAPHORE_TASK_LOG_ENABLED` | Aktiviert die Task-Protokollierung in eine Datei. |
-| `format`              | `SEMAPHORE_TASK_LOG_FORMAT`  | Format der Protokolleinträge. Kann `raw` oder `json` sein. |
-| `logger`              | `SEMAPHORE_TASK_LOG_LOGGER`  | [Logger-Optionen](#logger-options). |
+| `format`              | `SEMAPHORE_TASK_LOG_FORMAT`  | Format der Protokolleinträge. Für das Raw-Format leer lassen oder `json` festlegen. |
+| `logger`              | `SEMAPHORE_TASK_LOGGER`      | [Logger-Optionen](#logger-options). |
 | `result_logger`       | `SEMAPHORE_TASK_RESULT_LOGGER`  | Logger-Optionen. |
 
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/admin-guide/logs.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/admin-guide/logs.md
@@ -24,11 +24,10 @@ Esto proporciona una vista en vivo (en streaming) de los registros.
 
 ## Registro de actividad {#activity-log}
 
-El Registro de actividad captura todas las acciones de usuario realizadas en Semaphore, incluidas:
+El Registro de actividad captura acciones de usuario realizadas en Semaphore, incluidas:
 
 - Añadir o eliminar recursos (p. ej., Plantillas, Inventarios, Repositorios).
 - Añadir o eliminar miembros del equipo.
-- Iniciar o detener tareas.
 
 ### Versión Pro 2.10 y posteriores {#pro-version-210-and-later}
 
@@ -64,21 +63,21 @@ O puede hacerlo mediante las siguientes variables de entorno:
 
 ```bash
 export SEMAPHORE_EVENT_LOG_ENABLED=True
-export SEMAPHORE_EVENT_LOG_LOGGER={"filename": "./events.log"}
+export SEMAPHORE_EVENT_LOGGER={"filename": "./events.log"}
 
 export SEMAPHORE_TASK_LOG_ENABLED=True
-export SEMAPHORE_EVENT_LOG_LOGGER={"filename": "./tasks.log"}
+export SEMAPHORE_TASK_LOGGER={"filename": "./tasks.log"}
 ```
 
 #### Opciones de registro de actividad (eventos) {#activity-events-logging-options}
 
-Las opciones de registro de actividad (eventos) permiten configurar cómo Semaphore registra en un archivo las acciones de usuario y los eventos del sistema. Estos ajustes controlan el comportamiento del registro de eventos, incluido si está habilitado, el formato de las entradas de registro y la configuración específica del logger. Cuando está habilitado, todas las acciones de usuario (como crear plantillas, gestionar equipos o ejecutar tareas) se escribirán en el archivo de registro especificado según estos ajustes.
+Las opciones de registro de actividad (eventos) permiten configurar cómo Semaphore registra en un archivo las acciones de usuario y los eventos del sistema. Estos ajustes controlan el comportamiento del registro de eventos, incluido si está habilitado, el formato de las entradas de registro y la configuración específica del logger. Cuando está habilitado, las acciones de usuario como crear plantillas o gestionar equipos se escribirán en el archivo de registro especificado según estos ajustes.
 
 | Parámetro             | Variables de entorno | Descripción           |
 | --------------------- | --------------------- | --------------------- |
 | `enabled`             | `SEMAPHORE_EVENT_LOG_ENABLED` | Habilita el registro de eventos en archivo. |
-| `format`              | `SEMAPHORE_EVENT_LOG_FORMAT`  | Formato de los registros. Puede ser `raw` o `json`. |
-| `logger`              | `SEMAPHORE_EVENT_LOG_LOGGER`  | [Opciones del logger](#logger-options). |
+| `format`              | `SEMAPHORE_EVENT_LOG_FORMAT`  | Formato de los registros. Déjelo vacío para formato raw o establézcalo en `json`. |
+| `logger`              | `SEMAPHORE_EVENT_LOGGER`      | [Opciones del logger](#logger-options). |
 
 #### Opciones de registro de tareas {#tasks-logging-options}
 
@@ -87,8 +86,8 @@ Las opciones de registro de tareas permiten configurar cómo Semaphore registra 
 | Parámetro             | Variables de entorno | Descripción           |
 | --------------------- | --------------------- | --------------------- |
 | `enabled`             | `SEMAPHORE_TASK_LOG_ENABLED` | Habilita el registro de tareas en archivo. |
-| `format`              | `SEMAPHORE_TASK_LOG_FORMAT`  | Formato de los registros. Puede ser `raw` o `json`. |
-| `logger`              | `SEMAPHORE_TASK_LOG_LOGGER`  | [Opciones del logger](#logger-options). |
+| `format`              | `SEMAPHORE_TASK_LOG_FORMAT`  | Formato de los registros. Déjelo vacío para formato raw o establézcalo en `json`. |
+| `logger`              | `SEMAPHORE_TASK_LOGGER`      | [Opciones del logger](#logger-options). |
 | `result_logger`       | `SEMAPHORE_TASK_RESULT_LOGGER`  | Opciones del logger. |
 
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/admin-guide/logs.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/admin-guide/logs.md
@@ -24,11 +24,10 @@ Cela fournit une vue en direct (en flux continu) des journaux.
 
 ## Journal d'activité {#activity-log}
 
-Le journal d'activité enregistre toutes les actions effectuées par les utilisateurs dans Semaphore, notamment :
+Le journal d'activité enregistre les actions effectuées par les utilisateurs dans Semaphore, notamment :
 
 - L'ajout ou la suppression de ressources (par ex. modèles, inventaires, dépôts).
 - L'ajout ou la suppression de membres d'équipe.
-- Le démarrage ou l'arrêt de tâches.
 
 ### Version Pro 2.10 et ultérieures {#pro-version-210-and-later}
 
@@ -64,21 +63,21 @@ Ou vous pouvez le faire à l'aide des variables d'environnement suivantes :
 
 ```bash
 export SEMAPHORE_EVENT_LOG_ENABLED=True
-export SEMAPHORE_EVENT_LOG_LOGGER={"filename": "./events.log"}
+export SEMAPHORE_EVENT_LOGGER={"filename": "./events.log"}
 
 export SEMAPHORE_TASK_LOG_ENABLED=True
-export SEMAPHORE_EVENT_LOG_LOGGER={"filename": "./tasks.log"}
+export SEMAPHORE_TASK_LOGGER={"filename": "./tasks.log"}
 ```
 
 #### Options de journalisation de l'activité (événements) {#activity-events-logging-options}
 
-Les options de journalisation de l'activité (événements) vous permettent de configurer la manière dont Semaphore enregistre les actions des utilisateurs et les événements système dans un fichier. Ces paramètres contrôlent le comportement de la journalisation des événements, notamment son activation, le format des entrées de journal et la configuration spécifique du logger. Une fois activée, toutes les actions des utilisateurs (comme la création de modèles, la gestion des équipes ou l'exécution de tâches) seront écrites dans le fichier journal spécifié conformément à ces paramètres.
+Les options de journalisation de l'activité (événements) vous permettent de configurer la manière dont Semaphore enregistre les actions des utilisateurs et les événements système dans un fichier. Ces paramètres contrôlent le comportement de la journalisation des événements, notamment son activation, le format des entrées de journal et la configuration spécifique du logger. Une fois activée, les actions des utilisateurs comme la création de modèles ou la gestion des équipes seront écrites dans le fichier journal spécifié conformément à ces paramètres.
 
 | Paramètre             | Variables d'environnement | Description           |
 | --------------------- | --------------------- | --------------------- |
 | `enabled`             | `SEMAPHORE_EVENT_LOG_ENABLED` | Active la journalisation des événements dans un fichier. |
-| `format`              | `SEMAPHORE_EVENT_LOG_FORMAT`  | Format des enregistrements du journal. Peut être `raw` ou `json`. |
-| `logger`              | `SEMAPHORE_EVENT_LOG_LOGGER`  | [Options du logger](#logger-options). |
+| `format`              | `SEMAPHORE_EVENT_LOG_FORMAT`  | Format des enregistrements du journal. Laissez vide pour le format raw ou définissez `json`. |
+| `logger`              | `SEMAPHORE_EVENT_LOGGER`      | [Options du logger](#logger-options). |
 
 #### Options de journalisation des tâches {#tasks-logging-options}
 
@@ -87,8 +86,8 @@ Les options de journalisation des tâches vous permettent de configurer la mani�
 | Paramètre             | Variables d'environnement | Description           |
 | --------------------- | --------------------- | --------------------- |
 | `enabled`             | `SEMAPHORE_TASK_LOG_ENABLED` | Active la journalisation des tâches dans un fichier. |
-| `format`              | `SEMAPHORE_TASK_LOG_FORMAT`  | Format des enregistrements du journal. Peut être `raw` ou `json`. |
-| `logger`              | `SEMAPHORE_TASK_LOG_LOGGER`  | [Options du logger](#logger-options). |
+| `format`              | `SEMAPHORE_TASK_LOG_FORMAT`  | Format des enregistrements du journal. Laissez vide pour le format raw ou définissez `json`. |
+| `logger`              | `SEMAPHORE_TASK_LOGGER`      | [Options du logger](#logger-options). |
 | `result_logger`       | `SEMAPHORE_TASK_RESULT_LOGGER`  | Options du logger. |
 
 

--- a/i18n/it/docusaurus-plugin-content-docs/current/admin-guide/logs.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/admin-guide/logs.md
@@ -24,11 +24,10 @@ In questo modo si ottiene una vista in tempo reale (streaming) dei log.
 
 ## Registro attività {#activity-log}
 
-Il registro attività (Activity Log) acquisisce tutte le azioni degli utenti eseguite in Semaphore, tra cui:
+Il registro attività (Activity Log) acquisisce le azioni degli utenti eseguite in Semaphore, tra cui:
 
 - Aggiunta o rimozione di risorse (ad es. template, inventory, repository).
 - Aggiunta o rimozione di membri del team.
-- Avvio o arresto di attività.
 
 ### Versione Pro 2.10 e successive {#pro-version-210-and-later}
 
@@ -64,21 +63,21 @@ In alternativa, è possibile utilizzare le seguenti variabili d'ambiente:
 
 ```bash
 export SEMAPHORE_EVENT_LOG_ENABLED=True
-export SEMAPHORE_EVENT_LOG_LOGGER={"filename": "./events.log"}
+export SEMAPHORE_EVENT_LOGGER={"filename": "./events.log"}
 
 export SEMAPHORE_TASK_LOG_ENABLED=True
-export SEMAPHORE_EVENT_LOG_LOGGER={"filename": "./tasks.log"}
+export SEMAPHORE_TASK_LOGGER={"filename": "./tasks.log"}
 ```
 
 #### Opzioni di logging del registro attività (eventi) {#activity-events-logging-options}
 
-Le opzioni di logging del registro attività (eventi) permettono di configurare il modo in cui Semaphore registra su file le azioni degli utenti e gli eventi di sistema. Queste impostazioni controllano il comportamento del logging degli eventi, incluso se è abilitato, il formato delle voci di log e le configurazioni specifiche del logger. Quando è abilitato, tutte le azioni degli utenti (come la creazione di template, la gestione dei team o l'esecuzione di attività) vengono scritte nel file di log specificato in base a queste impostazioni.
+Le opzioni di logging del registro attività (eventi) permettono di configurare il modo in cui Semaphore registra su file le azioni degli utenti e gli eventi di sistema. Queste impostazioni controllano il comportamento del logging degli eventi, incluso se è abilitato, il formato delle voci di log e le configurazioni specifiche del logger. Quando è abilitato, le azioni degli utenti come la creazione di template o la gestione dei team vengono scritte nel file di log specificato in base a queste impostazioni.
 
 | Parametro             | Variabili d'ambiente | Descrizione           |
 | --------------------- | --------------------- | --------------------- |
 | `enabled`             | `SEMAPHORE_EVENT_LOG_ENABLED` | Abilita il logging degli eventi su file. |
-| `format`              | `SEMAPHORE_EVENT_LOG_FORMAT`  | Formato dei record di log. Può essere `raw` o `json`. |
-| `logger`              | `SEMAPHORE_EVENT_LOG_LOGGER`  | [Opzioni del logger](#logger-options). |
+| `format`              | `SEMAPHORE_EVENT_LOG_FORMAT`  | Formato dei record di log. Lasciare vuoto per il formato raw oppure impostare `json`. |
+| `logger`              | `SEMAPHORE_EVENT_LOGGER`      | [Opzioni del logger](#logger-options). |
 
 #### Opzioni di logging delle attività {#tasks-logging-options}
 
@@ -87,8 +86,8 @@ Le opzioni di logging delle attività permettono di configurare il modo in cui S
 | Parametro             | Variabili d'ambiente | Descrizione           |
 | --------------------- | --------------------- | --------------------- |
 | `enabled`             | `SEMAPHORE_TASK_LOG_ENABLED` | Abilita il logging delle attività su file. |
-| `format`              | `SEMAPHORE_TASK_LOG_FORMAT`  | Formato dei record di log. Può essere `raw` o `json`. |
-| `logger`              | `SEMAPHORE_TASK_LOG_LOGGER`  | [Opzioni del logger](#logger-options). |
+| `format`              | `SEMAPHORE_TASK_LOG_FORMAT`  | Formato dei record di log. Lasciare vuoto per il formato raw oppure impostare `json`. |
+| `logger`              | `SEMAPHORE_TASK_LOGGER`      | [Opzioni del logger](#logger-options). |
 | `result_logger`       | `SEMAPHORE_TASK_RESULT_LOGGER`  | Opzioni del logger. |
 
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/admin-guide/logs.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/admin-guide/logs.md
@@ -24,11 +24,10 @@ docker logs -f my-semaphore-container
 
 ## アクティビティログ {#activity-log}
 
-アクティビティログは、Semaphore で実行されたすべてのユーザー操作を記録します。たとえば次のような操作です。
+アクティビティログは、Semaphore で実行されたユーザー操作を記録します。たとえば次のような操作です。
 
 - リソース(テンプレート、インベントリ、リポジトリなど)の追加または削除。
 - チームメンバーの追加または削除。
-- タスクの開始または停止。
 
 ### Pro バージョン 2.10 以降 {#pro-version-210-and-later}
 
@@ -64,21 +63,21 @@ docker logs -f my-semaphore-container
 
 ```bash
 export SEMAPHORE_EVENT_LOG_ENABLED=True
-export SEMAPHORE_EVENT_LOG_LOGGER={"filename": "./events.log"}
+export SEMAPHORE_EVENT_LOGGER={"filename": "./events.log"}
 
 export SEMAPHORE_TASK_LOG_ENABLED=True
-export SEMAPHORE_EVENT_LOG_LOGGER={"filename": "./tasks.log"}
+export SEMAPHORE_TASK_LOGGER={"filename": "./tasks.log"}
 ```
 
 #### アクティビティ(イベント)ログのオプション {#activity-events-logging-options}
 
-アクティビティ(イベント)ログのオプションでは、Semaphore がユーザー操作やシステムイベントをファイルに記録する方法を設定できます。これらの設定は、有効化の有無、ログエントリの形式、ロガー固有の設定など、イベントログの動作を制御します。有効にすると、すべてのユーザー操作(テンプレートの作成、チームの管理、タスクの実行など)が、これらの設定に従って指定されたログファイルに書き込まれます。
+アクティビティ(イベント)ログのオプションでは、Semaphore がユーザー操作やシステムイベントをファイルに記録する方法を設定できます。これらの設定は、有効化の有無、ログエントリの形式、ロガー固有の設定など、イベントログの動作を制御します。有効にすると、テンプレートの作成やチームの管理などのユーザー操作が、これらの設定に従って指定されたログファイルに書き込まれます。
 
 | パラメータ             | 環境変数 | 説明           |
 | --------------------- | --------------------- | --------------------- |
 | `enabled`             | `SEMAPHORE_EVENT_LOG_ENABLED` | イベントログのファイル出力を有効にします。 |
-| `format`              | `SEMAPHORE_EVENT_LOG_FORMAT`  | ログレコードの形式。`raw` または `json` を指定できます。 |
-| `logger`              | `SEMAPHORE_EVENT_LOG_LOGGER`  | [ロガーのオプション](#logger-options)。 |
+| `format`              | `SEMAPHORE_EVENT_LOG_FORMAT`  | ログレコードの形式。raw 形式では空のままにするか、`json` を指定します。 |
+| `logger`              | `SEMAPHORE_EVENT_LOGGER`      | [ロガーのオプション](#logger-options)。 |
 
 #### タスクログのオプション {#tasks-logging-options}
 
@@ -87,8 +86,8 @@ export SEMAPHORE_EVENT_LOG_LOGGER={"filename": "./tasks.log"}
 | パラメータ             | 環境変数 | 説明           |
 | --------------------- | --------------------- | --------------------- |
 | `enabled`             | `SEMAPHORE_TASK_LOG_ENABLED` | タスクログのファイル出力を有効にします。 |
-| `format`              | `SEMAPHORE_TASK_LOG_FORMAT`  | ログレコードの形式。`raw` または `json` を指定できます。 |
-| `logger`              | `SEMAPHORE_TASK_LOG_LOGGER`  | [ロガーのオプション](#logger-options)。 |
+| `format`              | `SEMAPHORE_TASK_LOG_FORMAT`  | ログレコードの形式。raw 形式では空のままにするか、`json` を指定します。 |
+| `logger`              | `SEMAPHORE_TASK_LOGGER`      | [ロガーのオプション](#logger-options)。 |
 | `result_logger`       | `SEMAPHORE_TASK_RESULT_LOGGER`  | ロガーのオプション。 |
 
 

--- a/i18n/ko/docusaurus-plugin-content-docs/current/admin-guide/logs.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/admin-guide/logs.md
@@ -24,11 +24,10 @@ docker logs -f my-semaphore-container
 
 ## 활동 로그 {#activity-log}
 
-활동 로그는 Semaphore에서 수행된 모든 사용자 작업을 기록합니다. 예를 들면 다음과 같습니다:
+활동 로그는 Semaphore에서 수행된 사용자 작업을 기록합니다. 예를 들면 다음과 같습니다:
 
 - 리소스 추가 또는 제거(예: 템플릿, 인벤토리, 저장소).
 - 팀 구성원 추가 또는 제거.
-- 작업 시작 또는 중지.
 
 ### Pro 버전 2.10 이상 {#pro-version-210-and-later}
 
@@ -64,21 +63,21 @@ docker logs -f my-semaphore-container
 
 ```bash
 export SEMAPHORE_EVENT_LOG_ENABLED=True
-export SEMAPHORE_EVENT_LOG_LOGGER={"filename": "./events.log"}
+export SEMAPHORE_EVENT_LOGGER={"filename": "./events.log"}
 
 export SEMAPHORE_TASK_LOG_ENABLED=True
-export SEMAPHORE_EVENT_LOG_LOGGER={"filename": "./tasks.log"}
+export SEMAPHORE_TASK_LOGGER={"filename": "./tasks.log"}
 ```
 
 #### 활동(이벤트) 로깅 옵션 {#activity-events-logging-options}
 
-활동(이벤트) 로깅 옵션을 사용하면 Semaphore가 사용자 작업과 시스템 이벤트를 파일에 기록하는 방식을 구성할 수 있습니다. 이 설정은 이벤트 로깅의 활성화 여부, 로그 항목 형식, 세부 logger 구성 등 이벤트 로깅 동작을 제어합니다. 활성화하면 모든 사용자 작업(템플릿 생성, 팀 관리, 작업 실행 등)이 이 설정에 따라 지정된 로그 파일에 기록됩니다.
+활동(이벤트) 로깅 옵션을 사용하면 Semaphore가 사용자 작업과 시스템 이벤트를 파일에 기록하는 방식을 구성할 수 있습니다. 이 설정은 이벤트 로깅의 활성화 여부, 로그 항목 형식, 세부 logger 구성 등 이벤트 로깅 동작을 제어합니다. 활성화하면 템플릿 생성, 팀 관리 등의 사용자 작업이 이 설정에 따라 지정된 로그 파일에 기록됩니다.
 
 | 매개변수             | 환경 변수 | 설명           |
 | --------------------- | --------------------- | --------------------- |
 | `enabled`             | `SEMAPHORE_EVENT_LOG_ENABLED` | 파일로의 이벤트 로깅을 활성화합니다. |
-| `format`              | `SEMAPHORE_EVENT_LOG_FORMAT`  | 로그 레코드 형식. `raw` 또는 `json`을 사용할 수 있습니다. |
-| `logger`              | `SEMAPHORE_EVENT_LOG_LOGGER`  | [Logger 옵션](#logger-options). |
+| `format`              | `SEMAPHORE_EVENT_LOG_FORMAT`  | 로그 레코드 형식. raw 형식은 비워 두고, JSON 형식은 `json`으로 설정합니다. |
+| `logger`              | `SEMAPHORE_EVENT_LOGGER`      | [Logger 옵션](#logger-options). |
 
 #### 작업 로깅 옵션 {#tasks-logging-options}
 
@@ -87,8 +86,8 @@ export SEMAPHORE_EVENT_LOG_LOGGER={"filename": "./tasks.log"}
 | 매개변수             | 환경 변수 | 설명           |
 | --------------------- | --------------------- | --------------------- |
 | `enabled`             | `SEMAPHORE_TASK_LOG_ENABLED` | 파일로의 작업 로깅을 활성화합니다. |
-| `format`              | `SEMAPHORE_TASK_LOG_FORMAT`  | 로그 레코드 형식. `raw` 또는 `json`을 사용할 수 있습니다. |
-| `logger`              | `SEMAPHORE_TASK_LOG_LOGGER`  | [Logger 옵션](#logger-options). |
+| `format`              | `SEMAPHORE_TASK_LOG_FORMAT`  | 로그 레코드 형식. raw 형식은 비워 두고, JSON 형식은 `json`으로 설정합니다. |
+| `logger`              | `SEMAPHORE_TASK_LOGGER`      | [Logger 옵션](#logger-options). |
 | `result_logger`       | `SEMAPHORE_TASK_RESULT_LOGGER`  | Logger 옵션. |
 
 

--- a/i18n/pt/docusaurus-plugin-content-docs/current/admin-guide/logs.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/admin-guide/logs.md
@@ -24,11 +24,10 @@ Isso fornece uma visualização ao vivo (em streaming) dos logs.
 
 ## Log de atividade {#activity-log}
 
-O Log de Atividade registra todas as ações de usuários realizadas no Semaphore, incluindo:
+O Log de Atividade registra ações de usuários realizadas no Semaphore, incluindo:
 
 - Adição ou remoção de recursos (por exemplo, Templates, Inventários, Repositórios).
 - Adição ou remoção de membros da equipe.
-- Início ou interrupção de tarefas.
 
 ### Versão Pro 2.10 e posteriores {#pro-version-210-and-later}
 
@@ -64,21 +63,21 @@ Ou você pode fazer isso usando as seguintes variáveis de ambiente:
 
 ```bash
 export SEMAPHORE_EVENT_LOG_ENABLED=True
-export SEMAPHORE_EVENT_LOG_LOGGER={"filename": "./events.log"}
+export SEMAPHORE_EVENT_LOGGER={"filename": "./events.log"}
 
 export SEMAPHORE_TASK_LOG_ENABLED=True
-export SEMAPHORE_EVENT_LOG_LOGGER={"filename": "./tasks.log"}
+export SEMAPHORE_TASK_LOGGER={"filename": "./tasks.log"}
 ```
 
 #### Opções de log de atividade (eventos) {#activity-events-logging-options}
 
-As opções de log de Atividade (eventos) permitem configurar como o Semaphore registra ações de usuários e eventos do sistema em um arquivo. Essas configurações controlam o comportamento do log de eventos, incluindo se ele está habilitado, o formato dos registros de log e configurações específicas do logger. Quando habilitado, todas as ações de usuários (como criar templates, gerenciar equipes ou executar tarefas) serão gravadas no arquivo de log especificado de acordo com essas configurações.
+As opções de log de Atividade (eventos) permitem configurar como o Semaphore registra ações de usuários e eventos do sistema em um arquivo. Essas configurações controlam o comportamento do log de eventos, incluindo se ele está habilitado, o formato dos registros de log e configurações específicas do logger. Quando habilitado, ações de usuários como criar templates ou gerenciar equipes serão gravadas no arquivo de log especificado de acordo com essas configurações.
 
 | Parâmetro             | Variáveis de ambiente | Descrição             |
 | --------------------- | --------------------- | --------------------- |
 | `enabled`             | `SEMAPHORE_EVENT_LOG_ENABLED` | Habilita o log de eventos em arquivo. |
-| `format`              | `SEMAPHORE_EVENT_LOG_FORMAT`  | Formato do registro de log. Pode ser `raw` ou `json`. |
-| `logger`              | `SEMAPHORE_EVENT_LOG_LOGGER`  | [Opções do logger](#logger-options). |
+| `format`              | `SEMAPHORE_EVENT_LOG_FORMAT`  | Formato do registro de log. Deixe vazio para o formato raw ou defina como `json`. |
+| `logger`              | `SEMAPHORE_EVENT_LOGGER`      | [Opções do logger](#logger-options). |
 
 #### Opções de log de tarefas {#tasks-logging-options}
 
@@ -87,8 +86,8 @@ As opções de log de Tarefas permitem configurar como o Semaphore registra os d
 | Parâmetro             | Variáveis de ambiente | Descrição             |
 | --------------------- | --------------------- | --------------------- |
 | `enabled`             | `SEMAPHORE_TASK_LOG_ENABLED` | Habilita o log de tarefas em arquivo. |
-| `format`              | `SEMAPHORE_TASK_LOG_FORMAT`  | Formato do registro de log. Pode ser `raw` ou `json`. |
-| `logger`              | `SEMAPHORE_TASK_LOG_LOGGER`  | [Opções do logger](#logger-options). |
+| `format`              | `SEMAPHORE_TASK_LOG_FORMAT`  | Formato do registro de log. Deixe vazio para o formato raw ou defina como `json`. |
+| `logger`              | `SEMAPHORE_TASK_LOGGER`      | [Opções do logger](#logger-options). |
 | `result_logger`       | `SEMAPHORE_TASK_RESULT_LOGGER`  | Opções do logger. |
 
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/admin-guide/logs.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/admin-guide/logs.md
@@ -24,11 +24,10 @@ docker logs -f my-semaphore-container
 
 ## Лог активности {#activity-log}
 
-Лог активности фиксирует все действия пользователей в Semaphore, включая:
+Лог активности фиксирует действия пользователей в Semaphore, включая:
 
 - Добавление или удаление ресурсов (например, шаблонов, инвентарей, репозиториев).
 - Добавление или удаление участников команды.
-- Запуск или остановку задач.
 
 ### Pro-версия 2.10 и новее {#pro-version-210-and-later}
 
@@ -64,21 +63,21 @@ docker logs -f my-semaphore-container
 
 ```bash
 export SEMAPHORE_EVENT_LOG_ENABLED=True
-export SEMAPHORE_EVENT_LOG_LOGGER={"filename": "./events.log"}
+export SEMAPHORE_EVENT_LOGGER={"filename": "./events.log"}
 
 export SEMAPHORE_TASK_LOG_ENABLED=True
-export SEMAPHORE_EVENT_LOG_LOGGER={"filename": "./tasks.log"}
+export SEMAPHORE_TASK_LOGGER={"filename": "./tasks.log"}
 ```
 
 #### Параметры логирования активности (событий) {#activity-events-logging-options}
 
-Параметры логирования активности (событий) позволяют настроить, как Semaphore записывает действия пользователей и системные события в файл. Эти настройки управляют поведением логирования событий: включено ли оно, в каком формате записываются записи и какие параметры используются логгером. Когда логирование включено, все действия пользователей (создание шаблонов, управление командами, запуск задач и т. д.) записываются в указанный лог-файл в соответствии с этими настройками.
+Параметры логирования активности (событий) позволяют настроить, как Semaphore записывает действия пользователей и системные события в файл. Эти настройки управляют поведением логирования событий: включено ли оно, в каком формате записываются записи и какие параметры используются логгером. Когда логирование включено, действия пользователей (создание шаблонов, управление командами и т. д.) записываются в указанный лог-файл в соответствии с этими настройками.
 
 | Параметр              | Переменные окружения  | Описание              |
 | --------------------- | --------------------- | --------------------- |
 | `enabled`             | `SEMAPHORE_EVENT_LOG_ENABLED` | Включить логирование событий в файл. |
-| `format`              | `SEMAPHORE_EVENT_LOG_FORMAT`  | Формат записи лога. Может быть `raw` или `json`. |
-| `logger`              | `SEMAPHORE_EVENT_LOG_LOGGER`  | [Параметры логгера](#logger-options). |
+| `format`              | `SEMAPHORE_EVENT_LOG_FORMAT`  | Формат записи лога. Оставьте пустым для raw-формата или укажите `json`. |
+| `logger`              | `SEMAPHORE_EVENT_LOGGER`      | [Параметры логгера](#logger-options). |
 
 #### Параметры логирования задач {#tasks-logging-options}
 
@@ -87,8 +86,8 @@ export SEMAPHORE_EVENT_LOG_LOGGER={"filename": "./tasks.log"}
 | Параметр              | Переменные окружения  | Описание              |
 | --------------------- | --------------------- | --------------------- |
 | `enabled`             | `SEMAPHORE_TASK_LOG_ENABLED` | Включить логирование задач в файл. |
-| `format`              | `SEMAPHORE_TASK_LOG_FORMAT`  | Формат записи лога. Может быть `raw` или `json`. |
-| `logger`              | `SEMAPHORE_TASK_LOG_LOGGER`  | [Параметры логгера](#logger-options). |
+| `format`              | `SEMAPHORE_TASK_LOG_FORMAT`  | Формат записи лога. Оставьте пустым для raw-формата или укажите `json`. |
+| `logger`              | `SEMAPHORE_TASK_LOGGER`      | [Параметры логгера](#logger-options). |
 | `result_logger`       | `SEMAPHORE_TASK_RESULT_LOGGER`  | Параметры логгера. |
 
 


### PR DESCRIPTION
A task run does not create `events.log`, which can make a valid event-log configuration appear broken. Document the separation so operators enable and inspect the correct file.